### PR TITLE
Windows build convenience & small CI change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: cmake -S. -Bbuild -DGITHUB_CI=1 -DAUDIOVIZ_TESTS=1 -DLUAVIZ_EXECUTABLE=1
 
       - name: Build project
-        run: cmake --build build -j$(nproc)
+        run: cmake --build build --parallel
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -77,7 +77,7 @@ jobs:
         run: cmake -S. -Bbuild -DGITHUB_CI=1 -DAUDIOVIZ_TESTS=1 -DLUAVIZ_EXECUTABLE=1
 
       - name: Build project
-        run: cmake --build build -j$(sysctl -n hw.ncpu)
+        run: cmake --build build --parallel
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -109,7 +109,7 @@ jobs:
         run: cmake -S. -Bbuild -G "MinGW Makefiles" -DGITHUB_CI=1 -DLUAVIZ_BUILD_LUA=1 -DAUDIOVIZ_TESTS=1 -DLUAVIZ_EXECUTABLE=1
 
       - name: Build project
-        run: cmake --build build -j $env:NUMBER_OF_PROCESSORS
+        run: cmake --build build --parallel
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ windows_deps
 *.ini
 *.jpg
 *.webp
+*.ps1
+*.mp3

--- a/README.md
+++ b/README.md
@@ -14,19 +14,28 @@ below is a great video explaining some of the fundamentals of programming with a
 
 [Cinamark - How do computers even render audio...?](https://youtu.be/md79DDofGVo)
 
-## building
+## building & running
+
+### all platforms
+make sure you are running executables from the project root directory (the folder you git cloned)! this is because audioviz needs to find effect shader files, which are in `shaders`, and not copied to the `build` directory. (will change this eventually by having the shaders embedded in source code at compile time).
+
 ### linux
 1. install any required dependencies below
 2. run `cmake -S. -Bbuild && cmake --build build -j$(nproc)` or use your IDE of choice with CMake support
+3. run build executables from the project root (as explained above)
 
 ### windows
 1. install any required dependencies below using `winget`:
    - lua can be installed with `winget install devcom.lua`
    - ffmpeg can be installed with `winget install gyan.ffmpeg.shared`
 2. run `cmake -S. -Bbuild && cmake --build build` or use your IDE of choice with CMake support
+3. run build executables from the project root (as explained above)
+
+#### dll problem
+on 64-bit systems, built executables dynamically link to FFTW and PortAudio, which are downloaded by the CMake build system at configure time into the `build` directory (or whatever you passed to `-B` when configuring). so **if nothing happens when you run an audioviz executable from the terminal**, and it returned a non-zero exit code, you need to append `;build` to your `PATH` environment variable so that the libraries can be found. you can do this by running `$env:PATH += ';build'` in PowerShell, or `set PATH=%PATH%;build` in CMD. if you want this to persist for every PowerShell/CMD you open, add the *absolute* path to your `build` directory to your user environment variables.
 
 ### macOS
-havent tried building just yet because of lack of native opengl support (SFML requirement). but opengl -> metal compatibility layers exist; building/testing contributions are welcome!
+thanks to CI, i discovered that the build process is the same as with linux. just use brew for package management. however i don't own a functional mac at the moment and have **not** tested the CI builds.
 
 ## libraries/software used
 - **libaudioviz**

--- a/libaudioviz/deps.cmake
+++ b/libaudioviz/deps.cmake
@@ -44,6 +44,10 @@ if(WIN32 AND NOT FFTW3_FOUND)
 		target_link_directories(audioviz PUBLIC ${fftw_SOURCE_DIR})
 		target_include_directories(audioviz PUBLIC ${fftw_SOURCE_DIR})
 		target_link_libraries(audioviz PUBLIC fftw3f-3)
+
+		# this is so that we only need to append the build dir to the PATH before running,
+		# making that process a bit less error-prone
+		file(COPY ${fftw_SOURCE_DIR}/libfftw3f-3.dll DESTINATION ${CMAKE_BINARY_DIR})
 	else()
 		message("other architecture detected, fetching fftw source...")
 		set(BUILD_TESTS OFF)

--- a/luaviz/CMakeLists.txt
+++ b/luaviz/CMakeLists.txt
@@ -3,6 +3,13 @@ option(LUAVIZ_BUILD_LUA "Build Lua from source for luaviz" OFF)
 
 file(GLOB LUAVIZ_SOURCES src/*.cpp)
 
+if(WIN32)
+	# using a shared library loaded by devcom's lua.exe just freezes up the system? force executable on windows
+	# this COULD be only happening on my dev laptop which has hybrid graphics... test on other systems.
+	# but since a standalone executable works basically the same way, this is a sane default.
+	set(LUAVIZ_EXECUTABLE ON CACHE BOOL "" FORCE)
+endif()
+
 if(LUAVIZ_EXECUTABLE)
 	add_executable(luaviz ${LUAVIZ_SOURCES} src/exe/main.cpp)
 else()


### PR DESCRIPTION
- Make building & running on Windows easier
  - Add additional info to the README
  - Copy `libfftw3f-3.dll` to the CMake build directory so only the build directory needs to be added to Windows `PATH` environment variable
- Update CI to use `--parallel` CMake flag instead of writing OS-dependent shell invocations for the `make -j` option