### PR TITLE
Fix Windows widestring issues

### DIFF
--- a/libaudioviz/include/audioviz/util.hpp
+++ b/libaudioviz/include/audioviz/util.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <cstdio>
 #include <functional>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace audioviz::util
 {
@@ -23,5 +27,8 @@ std::string detect_vaapi_device();
 #endif
 
 std::optional<sf::Texture> getAttachedPicture(const std::string &mediaPath);
+
+FILE *popen_utf8(const std::string &command, const char *mode);
+sf::String utf8_to_sf_string(const std::string &text);
 
 } // namespace audioviz::util

--- a/libaudioviz/src/audioviz/SongMetadataDrawable.cpp
+++ b/libaudioviz/src/audioviz/SongMetadataDrawable.cpp
@@ -1,4 +1,5 @@
 #include <audioviz/SongMetadataDrawable.hpp>
+#include <audioviz/util.hpp>
 
 namespace audioviz
 {
@@ -12,9 +13,9 @@ SongMetadataDrawable::SongMetadataDrawable(sf::Text &title_text, sf::Text &artis
 void SongMetadataDrawable::use_metadata(const Media &media)
 {
 	if (const auto title = media.title(); !title.empty())
-		title_text.setString(title);
+		title_text.setString(util::utf8_to_sf_string(title));
 	if (const auto artist = media.artist(); !artist.empty())
-		artist_text.setString(artist);
+		artist_text.setString(util::utf8_to_sf_string(artist));
 }
 
 void SongMetadataDrawable::set_album_cover(const sf::Texture &txr, const sf::Vector2f size)

--- a/libaudioviz/src/audioviz/media/FfmpegPopenEncoder.cpp
+++ b/libaudioviz/src/audioviz/media/FfmpegPopenEncoder.cpp
@@ -61,7 +61,8 @@ FfmpegPopenEncoder::FfmpegPopenEncoder(
 	// end on shortest input stream
 	cmd_stream << "-shortest " << outfile;
 
-	ffmpeg = popen(cmd_stream.str().c_str(), POPEN_W_MODE);
+	const auto command = cmd_stream.str();
+	ffmpeg = util::popen_utf8(command, POPEN_W_MODE);
 	if (!ffmpeg)
 		throw std::runtime_error{"Failed to start ffmpeg process with popen" + std::string{strerror(errno)}};
 }

--- a/libaudioviz/src/audioviz/media/FfmpegPopenMedia.cpp
+++ b/libaudioviz/src/audioviz/media/FfmpegPopenMedia.cpp
@@ -21,7 +21,8 @@ FfmpegPopenMedia::FfmpegPopenMedia(const std::string &url, const sf::Vector2u vi
 		ss << "-i \"" << url << "\" ";
 		ss << "-f f32le - ";
 
-		if (!(audio = popen(ss.str().c_str(), POPEN_R_MODE)))
+		const auto command = ss.str();
+		if (!(audio = util::popen_utf8(command, POPEN_R_MODE)))
 			// fatal error: audio visualizers need audio...
 			throw std::runtime_error{std::string{"audio: popen: "} + strerror(errno)};
 	}
@@ -56,7 +57,8 @@ FfmpegPopenMedia::FfmpegPopenMedia(const std::string &url, const sf::Vector2u vi
 
 		ss << "-pix_fmt rgba -f rawvideo -";
 
-		if (!(video = popen(ss.str().c_str(), POPEN_R_MODE)))
+		const auto command = ss.str();
+		if (!(video = util::popen_utf8(command, POPEN_R_MODE)))
 			// non-fatal error, we can continue without video
 			perror("video: popen");
 	}

--- a/libaudioviz/src/audioviz/media/FfprobeMetadata.cpp
+++ b/libaudioviz/src/audioviz/media/FfprobeMetadata.cpp
@@ -1,11 +1,12 @@
 #include <audioviz/media/FfprobeMetadata.hpp>
+#include <audioviz/util.hpp>
 #include <iostream>
 #include <sstream>
 
 FfprobeMetadata::FfprobeMetadata(const std::string &media_url)
 {
 	const auto command{"ffprobe -v warning -show_format -show_streams -print_format json \"" + media_url + '"'};
-	const auto ffprobe{popen(command.c_str(), "r")};
+	const auto ffprobe{audioviz::util::popen_utf8(command, POPEN_R_MODE)};
 	if (!ffprobe)
 		throw std::runtime_error{std::string{"popen: "} + strerror(errno)};
 
@@ -21,7 +22,7 @@ FfprobeMetadata::FfprobeMetadata(const std::string &media_url)
 	case 0:
 		break;
 	default:
-		std::cerr << "ffmpeg failed with exit code " << status << '\n';
+		std::cerr << __func__ << ": pclose returned: " << status << '\n';
 		return;
 	}
 

--- a/ttviz/src/real-main.cpp
+++ b/ttviz/src/real-main.cpp
@@ -1,6 +1,9 @@
 #include "Main.hpp"
 
-int main(const int argc, const char *const *const argv)
+#include <stdexcept>
+#include <vector>
+
+static int run_main(const int argc, const char *const *const argv)
 {
 	try
 	{
@@ -11,4 +14,56 @@ int main(const int argc, const char *const *const argv)
 		std::cerr << "audioviz: " << e.what() << '\n';
 		return EXIT_FAILURE;
 	}
+
+	return EXIT_SUCCESS;
 }
+
+#ifndef _WIN32
+
+int main(const int argc, const char *const *const argv)
+{
+	return run_main(argc, argv);
+}
+
+#else
+
+#include <Windows.h>
+#include <shellapi.h>
+
+static std::string wide_to_utf8(const wchar_t *wide)
+{
+	if (!wide)
+		return {};
+	const auto required = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
+	if (required <= 0)
+		throw std::runtime_error{"WideCharToMultiByte failed"};
+	std::string utf8(static_cast<size_t>(required), '\0');
+	if (WideCharToMultiByte(CP_UTF8, 0, wide, -1, utf8.data(), required, nullptr, nullptr) <= 0)
+		throw std::runtime_error{"WideCharToMultiByte failed"};
+	utf8.resize(static_cast<size_t>(required - 1));
+	return utf8;
+}
+
+int main()
+{
+	int argc = 0;
+	const auto wide_argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+	if (!wide_argv)
+		return run_main(__argc, __argv);
+
+	std::vector<std::string> utf8_args;
+	utf8_args.reserve(static_cast<size_t>(argc));
+	for (int i = 0; i < argc; ++i)
+		utf8_args.emplace_back(wide_to_utf8(wide_argv[i]));
+
+	std::vector<const char *> c_args;
+	c_args.reserve(utf8_args.size());
+	for (const auto &arg : utf8_args)
+		c_args.push_back(arg.c_str());
+
+	LocalFree(wide_argv);
+
+	return run_main(static_cast<int>(c_args.size()), c_args.data());
+}
+
+#endif


### PR DESCRIPTION
- Properly get widestrings from the passed arguments via Windows API
- Convert to `sf::String` just before passing to `sf::Text` to render characters properly
- Closes #21 

Unfinished business:
- CJK characters still show up as blocks when rendered, this is *usually* an indication that the font doesn't have CJK glyphs but I'll need to double check the same doesn't happen on Linux