### PR TITLE
Revamp of `ScopeDrawable` and the scope/spectrum test programs

### DIFF
--- a/libaudioviz/deps.cmake
+++ b/libaudioviz/deps.cmake
@@ -21,10 +21,8 @@ else()
 endif()
 
 ## OpenGL (also caused by optimization changes)
-if(APPLE OR WIN32)
-	find_package(OpenGL COMPONENTS OpenGL REQUIRED)
-	target_link_libraries(audioviz PUBLIC OpenGL::GL)
-endif()
+find_package(OpenGL COMPONENTS OpenGL REQUIRED)
+target_link_libraries(audioviz PUBLIC OpenGL::GL)
 
 ## fftw
 if(NOT ANDROID)
@@ -78,12 +76,21 @@ FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download
 FetchContent_MakeAvailable(json)
 target_link_libraries(audioviz PUBLIC nlohmann_json::nlohmann_json)
 
+## r8brain-free-src
+FetchContent_Declare(r8brain-free-src URL https://github.com/avaneev/r8brain-free-src/archive/master.tar.gz)
+FetchContent_MakeAvailable(r8brain-free-src)
+target_include_directories(audioviz PUBLIC ${r8brain-free-src_SOURCE_DIR})
+target_sources(audioviz PUBLIC
+    ${r8brain-free-src_SOURCE_DIR}/r8bbase.cpp
+    ${r8brain-free-src_SOURCE_DIR}/pffft.cpp
+)
+
 ### TEMPORARY - libaudioviz should not be responsible for audio playback.
 ### but to keep things stable i will leave this as is for now.
 ## portaudio (optional)
 if(AUDIOVIZ_USE_PORTAUDIO)
-	FetchContent_Declare(portaudio-pp URL https://github.com/trustytrojan/portaudio-pp/archive/main.tar.gz)
-	FetchContent_MakeAvailable(portaudio-pp)
-	target_compile_definitions(audioviz PUBLIC AUDIOVIZ_PORTAUDIO)
-	target_link_libraries(audioviz PUBLIC portaudio-pp::portaudio-pp)
+    FetchContent_Declare(portaudio-pp URL https://github.com/trustytrojan/portaudio-pp/archive/main.tar.gz)
+    FetchContent_MakeAvailable(portaudio-pp)
+    target_compile_definitions(audioviz PUBLIC AUDIOVIZ_PORTAUDIO)
+    target_link_libraries(audioviz PUBLIC portaudio-pp::portaudio-pp)
 endif()

--- a/libaudioviz/deps.cmake
+++ b/libaudioviz/deps.cmake
@@ -76,15 +76,6 @@ FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download
 FetchContent_MakeAvailable(json)
 target_link_libraries(audioviz PUBLIC nlohmann_json::nlohmann_json)
 
-## r8brain-free-src
-FetchContent_Declare(r8brain-free-src URL https://github.com/avaneev/r8brain-free-src/archive/master.tar.gz)
-FetchContent_MakeAvailable(r8brain-free-src)
-target_include_directories(audioviz PUBLIC ${r8brain-free-src_SOURCE_DIR})
-target_sources(audioviz PUBLIC
-    ${r8brain-free-src_SOURCE_DIR}/r8bbase.cpp
-    ${r8brain-free-src_SOURCE_DIR}/pffft.cpp
-)
-
 ### TEMPORARY - libaudioviz should not be responsible for audio playback.
 ### but to keep things stable i will leave this as is for now.
 ## portaudio (optional)

--- a/libaudioviz/include/audioviz/Base.hpp
+++ b/libaudioviz/include/audioviz/Base.hpp
@@ -34,8 +34,13 @@ protected:
 private:
 	std::vector<const sf::Drawable *> final_drawables;
 	int framerate{60};
+
+protected:
+	// audio frames per video frame
+	int afpvf{media->audio_sample_rate() / framerate};
 	int audio_frames_needed{};
-	int afpvf{media->audio_sample_rate() / framerate}; // audio frames per video frame
+
+private:
 	RenderTexture final_rt;
 
 	sf::Text timing_text{font};
@@ -55,7 +60,7 @@ private:
 	// PortAudio stuff for live playback
 	pa::Init pa_init;
 	pa::Stream pa_stream{0, 2, paFloat32, media->audio_sample_rate(), afpvf};
-	bool audio_enabled{true};
+	bool audio_enabled{};
 #endif
 
 public:

--- a/libaudioviz/include/audioviz/ScopeDrawable.hpp
+++ b/libaudioviz/include/audioviz/ScopeDrawable.hpp
@@ -100,6 +100,7 @@ public:
 
 			shapes[i].setFillColor(color.calculate_color((float)i / shapes.size()));
 
+			// only rectangles have `setSize`, not circles
 			if constexpr (std::is_base_of_v<sf::RectangleShape, ShapeType>)
 				if (!fill_in)
 				{

--- a/libaudioviz/include/audioviz/ScopeDrawable.hpp
+++ b/libaudioviz/include/audioviz/ScopeDrawable.hpp
@@ -3,7 +3,6 @@
 #include <SFML/Graphics.hpp>
 #include <algorithm>
 #include <audioviz/ColorSettings.hpp>
-#include <cmath>
 #include <span>
 
 namespace audioviz
@@ -20,8 +19,6 @@ class ScopeDrawable : public sf::Drawable
 	} shape;
 	bool fill_in = false;
 	const ColorSettings &color;
-	sf::Angle angle = sf::degrees(0);
-	sf::Transformable tf;
 	std::vector<ShapeType> shapes;
 
 public:
@@ -67,50 +64,70 @@ public:
 
 	void set_fill_in(const bool b) { fill_in = b; }
 	void set_backwards(const bool b) { backwards = b; }
-	void set_rotation_angle(const sf::Angle angle) { tf.setRotation(angle); }
-
-	void set_center_point(const double radius, const sf::Angle angle)
-	{
-		sf::Vector2f origin_{rect.size.x / 2.f, rect.size.y / 2.f};
-		sf::Vector2f coord{origin_.x + radius * cos(angle.asRadians()), origin_.y - radius * sin(angle.asRadians())};
-		tf.setPosition({coord});
-	}
-
 	size_t get_shape_count() const { return shapes.size(); }
 
 	void update(const std::span<float> &audio)
 	{
-		assert(audio.size() >= shapes.size());
-
 		for (int i = 0; i < (int)shapes.size(); ++i)
 		{
+			float audio_val;
+			if (audio.empty())
+			{
+				audio_val = 0.0f;
+			}
+			else if (shapes.size() == 1)
+			{
+				audio_val = audio[0];
+			}
+			else if (audio.size() == shapes.size())
+			{
+				audio_val = audio[i];
+			}
+			else
+			{
+				float t = static_cast<float>(i) / (shapes.size() - 1);
+				float pos = t * (audio.size() - 1);
+				size_t idx = static_cast<size_t>(pos);
+				float frac = pos - idx;
+				if (idx + 1 < audio.size())
+					audio_val = audio[idx] * (1 - frac) + audio[idx + 1] * frac;
+				else
+					audio_val = audio[idx];
+			}
+
 			const auto half_height = rect.size.y / 2.f;
 			const auto half_heightx = rect.size.x / 2.f;
 
 			shapes[i].setFillColor(color.calculate_color((float)i / shapes.size()));
 
-			if (!fill_in)
-			{
-				shapes[i].setPosition({
-					shapes[i].getPosition().x,
-					std::clamp(half_height + (-half_height * audio[i]), 0.f, (float)rect.size.y),
-				});
-			}
+			if constexpr (std::is_base_of_v<sf::RectangleShape, ShapeType>)
+				if (!fill_in)
+				{
+					shapes[i].setPosition({
+						shapes[i].getPosition().x,
+						std::clamp(half_height + (-half_height * audio_val), 0.f, (float)rect.size.y),
+					});
+				}
+				else
+				{
+					shapes[i].setPosition({
+						shapes[i].getPosition().x,
+						std::clamp(half_height, 0.f, (float)rect.size.y),
+					});
+					shapes[i].setSize({shape.width, (-half_height * audio_val)});
+				}
 			else
-			{
 				shapes[i].setPosition({
 					shapes[i].getPosition().x,
-					std::clamp(half_height, 0.f, (float)rect.size.y),
+					std::clamp(half_height + (-half_height * audio_val), 0.f, (float)rect.size.y),
 				});
-				shapes[i].setSize({shape.width, (-half_height * audio[i])});
-			}
 		}
 	}
 
 	void draw(sf::RenderTarget &target, sf::RenderStates states) const override
 	{
 		for (const auto &shape : shapes)
-			target.draw(shape, tf.getTransform());
+			target.draw(shape, states);
 	}
 
 private:
@@ -122,7 +139,7 @@ private:
 		for (int i = 0; i < shapes.size(); ++i)
 		{
 			if constexpr (std::is_base_of_v<sf::CircleShape, ShapeType>)
-				shapes[i].setRadius(shape.width);
+				shapes[i].setRadius(shape.width / 2.f);
 			else if constexpr (std::is_base_of_v<sf::RectangleShape, ShapeType>)
 				shapes[i].setSize({shape.width, shape.width});
 			else

--- a/libaudioviz/include/audioviz/SpectrumDrawable.hpp
+++ b/libaudioviz/include/audioviz/SpectrumDrawable.hpp
@@ -83,8 +83,17 @@ public:
 		update_bars();
 	}
 
+	/**
+	 * Use this to resize the analyzer's spectrum vector to be the same length
+	 * as the number of bars we are rendering. This is REQUIRED before calling `update`.
+	 */
 	void configure_analyzer(fft::AudioAnalyzer &aa) { aa.resize(bars.size()); }
 
+	/**
+	 * Update the heights of the bars using the provided `spectrum` data.
+	 * Requires that `spectrum.size() >= bars.size()`. Call `configure_analyzer`
+	 * before performing FFT to satisfy that requirement.
+	 */
 	void update(const std::vector<float> &spectrum)
 	{
 		assert(spectrum.size() >= bars.size());
@@ -95,28 +104,27 @@ public:
 		}
 	}
 
-	void update_colors()
-	{
-		for (int i = 0; i < (int)bars.size(); ++i)
-			bars[i].setFillColor(color.calculate_color((float)i / bars.size()));
-	}
-
 	void draw(sf::RenderTarget &target, sf::RenderStates states) const override
 	{
 		for (const auto &bar : bars)
 			target.draw(bar, states);
 		if (debug_rect)
 		{
+			// shows the rect of the object
 			sf::RectangleShape r{sf::Vector2f{rect.size}};
 			r.setFillColor(sf::Color::Transparent);
 			r.setOutlineThickness(1);
-			r.setOutlineColor(sf::Color::White);
 			r.setPosition(sf::Vector2f{rect.position});
+
+			// shows the origin of the object
 			sf::CircleShape c{5};
 			c.setPosition(sf::Vector2f{rect.position});
+
+			// draw with states,
 			target.draw(r, states);
 			target.draw(c, states);
 
+			// then draw without any states in red, to show how any render states may have transformed the object
 			r.setOutlineColor(sf::Color::Red);
 			c.setFillColor(sf::Color::Red);
 			target.draw(r);

--- a/libaudioviz/include/audioviz/StereoScope.hpp
+++ b/libaudioviz/include/audioviz/StereoScope.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <audioviz/ScopeDrawable.hpp>
+
+namespace audioviz
+{
+
+template <typename ShapeType>
+class StereoScope : public sf::Drawable
+{
+	ScopeDrawable<ShapeType> _left, _right;
+	sf::IntRect rect;
+
+public:
+	StereoScope(const ColorSettings &left_color, const ColorSettings &right_color)
+		: _left{left_color},
+		  _right{right_color}
+	{
+	}
+
+	StereoScope(const sf::IntRect &rect, const ColorSettings &left_color, const ColorSettings &right_color)
+		: _left{left_color},
+		  _right{right_color},
+		  rect{rect}
+	{
+		update_scope_rects();
+	}
+
+	void set_left_backwards(const bool b) { _left.set_backwards(b); }
+	void set_right_backwards(const bool b) { _right.set_backwards(b); }
+
+	void set_shape_spacing(int spacing)
+	{
+		_left.set_shape_spacing(spacing);
+		_right.set_shape_spacing(spacing);
+	}
+
+	void set_shape_width(int width)
+	{
+		_left.set_shape_width(width);
+		_right.set_shape_width(width);
+	}
+
+	void set_fill_in(const bool b)
+	{
+		_left.set_fill_in(b);
+		_right.set_fill_in(b);
+	}
+
+	void set_rect(const sf::IntRect &rect)
+	{
+		if (this->rect == rect)
+			return;
+		this->rect = rect;
+		update_scope_rects();
+	}
+
+	size_t get_shape_count() const
+	{
+		assert(_left.get_shape_count() == _right.get_shape_count());
+		return _left.get_shape_count();
+	}
+
+	void update(const std::span<float> &left, const std::span<float> &right)
+	{
+		_left.update(left);
+		_right.update(right);
+	}
+
+	void draw(sf::RenderTarget &target, sf::RenderStates states = {}) const override
+	{
+		target.draw(_left, states);
+		target.draw(_right, states);
+	}
+
+private:
+	void update_scope_rects()
+	{
+		_left.set_rect(rect);
+		_right.set_rect(rect);
+	}
+};
+
+} // namespace audioviz

--- a/libaudioviz/include/audioviz/StereoSpectrum.hpp
+++ b/libaudioviz/include/audioviz/StereoSpectrum.hpp
@@ -19,9 +19,23 @@ public:
 	{
 	}
 
+	StereoSpectrum(const ColorSettings &colorL, const ColorSettings &colorR)
+		: _left{colorL},
+		  _right{colorR}
+	{
+	}
+
 	StereoSpectrum(const sf::IntRect &rect, const ColorSettings &color)
 		: _left{color},
 		  _right{color},
+		  rect{rect}
+	{
+		update_spectrum_rects();
+	}
+
+	StereoSpectrum(const sf::IntRect &rect, const ColorSettings &colorL, const ColorSettings &colorR)
+		: _left{colorL},
+		  _right{colorR},
 		  rect{rect}
 	{
 		update_spectrum_rects();

--- a/libaudioviz/include/audioviz/VerticalPill.hpp
+++ b/libaudioviz/include/audioviz/VerticalPill.hpp
@@ -22,6 +22,7 @@ public:
 	VerticalPill(float width = 0, float height = 0, std::size_t pointCount = 30);
 	void setWidth(float width);
 	void setHeight(float height);
+	void setSize(sf::Vector2f size);
 	sf::Vector2f getPoint(std::size_t index) const override;
 };
 

--- a/libaudioviz/src/audioviz/VerticalPill.cpp
+++ b/libaudioviz/src/audioviz/VerticalPill.cpp
@@ -25,6 +25,12 @@ void VerticalPill::setHeight(const float height)
 	update();
 }
 
+void VerticalPill::setSize(const sf::Vector2f size)
+{
+	setWidth(size.x);
+	setHeight(size.y);
+}
+
 sf::Vector2f VerticalPill::getPoint(const std::size_t index) const
 {
 	const auto angle = static_cast<float>(index) / static_cast<float>(getPointCount()) * sf::degrees(360);

--- a/luaviz/src/load_BSC.cpp
+++ b/luaviz/src/load_BSC.cpp
@@ -23,8 +23,6 @@ void table::load_BSC()
 		"set_shape_spacing", &SD::set_shape_spacing,
 		"set_fill_in", &SD::set_fill_in,
 		"set_backwards", &SD::set_backwards,
-		"set_rotation_angle", &SD::set_rotation_angle,
-		"set_center_point", &SD::set_center_point,
 		sol::base_classes, sol::bases<sf::Drawable>()
 	);
 	// clang-format on

--- a/luaviz/src/load_BSD.cpp
+++ b/luaviz/src/load_BSD.cpp
@@ -27,7 +27,6 @@ void table::load_BSD()
 		"configure_analyzer", &SD::configure_analyzer,
 		"bar_count", &SD::bar_count,
 		"update", &SD::update,
-		"update_colors", &SD::update_colors,
 		"set_debug_rect", &SD::set_debug_rect
 	);
 	// clang-format on

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-link_libraries(audioviz sfml-graphics sfml-window sfml-system)
-add_executable(scope-colors-test scope-colors-test.cpp)
+link_libraries(audioviz)
+# add_executable(scope-colors-test scope-colors-test.cpp)
 add_executable(scope-test scope-test.cpp)
 add_executable(spectrum-test spectrum-test.cpp)
 add_executable(glow-test glow-test.cpp)

--- a/tests/scope-test.cpp
+++ b/tests/scope-test.cpp
@@ -1,10 +1,64 @@
+#include <audioviz/Base.hpp>
 #include <audioviz/ScopeDrawable.hpp>
 #include <audioviz/SpectrumDrawable.hpp>
-#include <audioviz/VerticalBar.hpp>
 #include <audioviz/fft/FrequencyAnalyzer.hpp>
+#include <audioviz/media/FfmpegPopenMedia.hpp>
 #include <audioviz/media/Media.hpp>
+
+#include <SFML/Graphics.hpp>
 #include <iostream>
 #include <portaudio.hpp>
+
+struct ScopeTest : audioviz::Base
+{
+	audioviz::ColorSettings colorL, colorR;
+	audioviz::ScopeDrawable<sf::CircleShape> scopeL, scopeR;
+	ScopeTest(sf::Vector2u size, const std::string &media_url);
+};
+
+ScopeTest::ScopeTest(sf::Vector2u size, const std::string &media_url)
+	: Base{size, new audioviz::FfmpegPopenMedia{media_url, size}},
+	  scopeL{{{}, (sf::Vector2i)size}, colorL},
+	  scopeR{{{}, (sf::Vector2i)size}, colorR}
+{
+	colorL.set_mode(audioviz::ColorSettings::Mode::SOLID);
+	colorL.set_solid_color(sf::Color::Red);
+	colorR.set_mode(audioviz::ColorSettings::Mode::SOLID);
+	colorR.set_solid_color(sf::Color::Cyan);
+
+	const auto width = 10, spacing = 3;
+
+	scopeL.set_shape_spacing(spacing);
+	scopeR.set_shape_spacing(spacing);
+	scopeL.set_shape_width(width);
+	scopeR.set_shape_width(width);
+	assert(scopeL.get_shape_count() == scopeR.get_shape_count());
+	scopeL.set_fill_in(true);
+	scopeR.set_fill_in(true);
+
+	set_audio_playback_enabled(true);
+
+	auto &scope_layer = add_layer("scope");
+	scope_layer.add_drawable(&scopeL);
+	scope_layer.add_drawable(&scopeR);
+	scope_layer.set_orig_cb(
+		[&](auto &orig_rt)
+		{
+			float left_channel[afpvf];
+			float right_channel[afpvf];
+			for (int i = 0; i < afpvf; ++i)
+			{
+				const auto &buf = media->audio_buffer();
+				const auto frame_idx = i * media->audio_channels();
+				left_channel[i] = buf[frame_idx];
+				right_channel[i] = buf[frame_idx + 1];
+			}
+			scopeL.update({left_channel, afpvf});
+			scopeR.update({right_channel, afpvf});
+		});
+
+	start_in_window("scope-test");
+}
 
 int main(const int argc, const char *const *const argv)
 {
@@ -15,108 +69,5 @@ int main(const int argc, const char *const *const argv)
 	}
 
 	const sf::Vector2u size{atoi(argv[1]), atoi(argv[2])};
-	sf::RenderWindow window{
-		sf::VideoMode{size}, "ScopeDrawableTest", sf::Style::Titlebar, sf::State::Windowed, {.antiAliasingLevel = 4}};
-	window.setVerticalSyncEnabled(true);
-
-	audioviz::ColorSettings color;
-	color.set_mode(audioviz::ColorSettings::Mode::WHEEL);
-	color.set_wheel_rate(.005);
-
-	audioviz::ScopeDrawable<sf::RectangleShape> scope{{{}, (sf::Vector2i)size}, color};
-	scope.set_shape_spacing(0);
-	scope.set_shape_width(1);
-	scope.set_fill_in(false);
-	std::cout << "shape count: " << scope.get_shape_count() << '\n';
-
-	audioviz::SpectrumDrawable<audioviz::VerticalBar> sd{{}, color};
-	sd.set_rect({{}, (sf::Vector2i)size});
-	sd.set_bar_width(1);
-	sd.set_bar_spacing(0);
-	// sd.set_color_mode(viz::SpectrumDrawable<viz::VerticalBar>::ColorMode::WHEEL);
-	// sd.set_color_wheel_rate(0.005);
-
-	const auto fft_size = size.x;
-	audioviz::fft::FrequencyAnalyzer fa{fft_size};
-
-	std::unique_ptr<audioviz::Media> media{audioviz::Media::create(argv[3])};
-
-	int afpvf{media->audio_sample_rate() / 60};
-
-	std::vector<float> left_channel(scope.get_shape_count()), spectrum(fft_size);
-
-	pa::Init _;
-	pa::Stream pa_stream{0, media->audio_channels(), paFloat32, media->audio_sample_rate()};
-	pa_stream.start();
-
-	const sf::Vector2f _origin{size.x / 2.f, size.y / 2.f};
-
-	const auto rad = 3;
-	sf::CircleShape origincircle{rad};
-	origincircle.setFillColor(sf::Color::Red);
-	origincircle.setOrigin({rad / 2.f, rad / 2.f});
-
-	double cur = 0;
-
-	origincircle.setPosition(_origin);
-
-	while (window.isOpen())
-	{
-		cur += .1;
-		while (const auto event = window.pollEvent())
-			if (event->is<sf::Event::Closed>())
-				window.close();
-
-		{
-			media->buffer_audio(scope.get_shape_count());
-
-			if (media->audio_buffer().size() < scope.get_shape_count())
-				break;
-
-			// copy just the left channel
-			for (int i = 0; i < scope.get_shape_count(); ++i)
-				left_channel[i] = media->audio_buffer()[i * media->audio_channels() + 0 /* left channel */];
-			scope.update(left_channel);
-
-			fa.copy_to_input(left_channel.data());
-			fa.render(spectrum);
-			sd.update(spectrum);
-
-			color.increment_wheel_time();
-
-			try
-			{
-				pa_stream.write(media->audio_buffer().data(), afpvf);
-			}
-			catch (const pa::Error &e)
-			{
-				if (e.code != paOutputUnderflowed)
-					throw;
-				std::cerr << e.what() << '\n';
-			}
-			media->audio_buffer_erase(afpvf);
-		}
-		double spin_arc = 360;
-		double speed = 20;
-
-		// tf.setRotation(sf::degrees(spin_arc*sin(cur/speed)));
-		// tf.setRotation(sf::degrees(speed*sin(cur) + speed*cur));
-		// tf.setRotation(sf::degrees(exp(cur/5 + 2*sin(cur))));
-		// tf.setRotation(sf::degrees(2*sin(cur)*exp(2*sin(cur))));
-		// float max_channel = 30 * (*std::max_element(left_channel.begin(), left_channel.end()));
-		// tf.setRotation(5*sf::degrees(max_channel));
-		sf::Angle ang_deg = sf::degrees(-7 * cur);
-		sf::Angle ang_deg2 = sf::degrees(90 + 7 * cur);
-
-		// scope.set_rotation_angle(ang_deg);
-		sf::Vector2f coord{150, 20};
-
-		// scope.set_center_point(150, ang_deg2);
-
-		window.clear();
-		window.draw(scope);
-		// window.draw(sd, tf.getTransform());
-		window.draw(origincircle);
-		window.display();
-	}
+	ScopeTest viz{size, argv[3]};
 }


### PR DESCRIPTION
- We didn't need an audio resampling library after all, just use a cherry-picking strategy to "lower" the resolution of the input audio to the number of scope objects
- Implement `StereoScope`, self-explanatory class
  - May also want to have the layout of the two scopes customizable, but that can come in the future
- Change the test programs to use `Base`, foregoing a ton of boilerplate, and actually testing a core part of the library. I'll also start following the Unix philosophy when it comes to the test programs 