### PR TITLE
Optimize `FrequencyAnalyzer` some more

### DIFF
--- a/libaudioviz/CMakeLists.txt
+++ b/libaudioviz/CMakeLists.txt
@@ -20,9 +20,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	target_compile_options(audioviz PUBLIC -Wno-subobject-linkage)
 endif()
 
-target_compile_options(audioviz
-	PUBLIC -Wno-narrowing
-	PUBLIC -ffast-math
+target_compile_options(audioviz PUBLIC
+	-Wno-narrowing
+	-ffast-math
+	-mavx2
 )
 
 target_include_directories(audioviz

--- a/libaudioviz/CMakeLists.txt
+++ b/libaudioviz/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 target_compile_options(audioviz PUBLIC
 	-Wno-narrowing
 	-ffast-math
-	-mavx2
 )
 
 target_include_directories(audioviz

--- a/libaudioviz/include/audioviz/fft/FrequencyAnalyzer.hpp
+++ b/libaudioviz/include/audioviz/fft/FrequencyAnalyzer.hpp
@@ -80,7 +80,8 @@ private:
 		void calc(const FrequencyAnalyzer &fa);
 	} scale_max;
 
-	std::vector<float> index_ratios;
+	int known_spectrum_size{};
+	std::vector<int> fftw_to_spectrum_index;
 	std::vector<float, fftw_allocator<float>> window_values;
 	std::vector<double> m_spline_x, m_spline_y;
 
@@ -159,7 +160,6 @@ public:
 	void render(std::vector<float> &spectrum);
 
 private:
-	int calc_index(int i, int max_index) const;
 	float calc_index_ratio(float i) const;
 	void interpolate(std::vector<float> &spectrum);
 	void compute_index_ratios();

--- a/libaudioviz/include/audioviz/fft/FrequencyAnalyzer.hpp
+++ b/libaudioviz/include/audioviz/fft/FrequencyAnalyzer.hpp
@@ -82,6 +82,7 @@ private:
 
 	int known_spectrum_size{};
 	std::vector<int> fftw_to_spectrum_index;
+	std::vector<std::pair<int, int>> spectrum_to_fftw_indices;
 	std::vector<float, fftw_allocator<float>> window_values;
 	std::vector<double> m_spline_x, m_spline_y;
 

--- a/libaudioviz/include/audioviz/fft/fftwf_dft_r2c_1d.hpp
+++ b/libaudioviz/include/audioviz/fft/fftwf_dft_r2c_1d.hpp
@@ -7,7 +7,7 @@ namespace audioviz::fft
 
 class fftwf_dft_r2c_1d
 {
-	int N;
+	int N, outN;
 	float *in;
 	fftwf_complex *out;
 	fftwf_plan p;
@@ -24,7 +24,7 @@ public:
 	inline float *input() { return in; }
 	inline const fftwf_complex *output() const { return out; }
 	inline int input_size() const { return N; }
-	inline int output_size() const { return N / 2 + 1; }
+	inline int output_size() const { return outN; }
 };
 
 } // namespace audioviz::fft

--- a/libaudioviz/src/audioviz/Base.cpp
+++ b/libaudioviz/src/audioviz/Base.cpp
@@ -87,11 +87,11 @@ bool Base::next_frame()
 
 	if (tt_enabled)
 	{
-		auto s = std::format("{:<20}{:<6}{:<6}{:<6}{:<6}\n", "", "curr", "avg", "min", "max");
+		auto s = std::format("{:<20}{:<7}{:<7}{:<7}{:<7}\n", "", "curr", "avg", "min", "max");
 		for (const auto &[label, stat] : timing_stats)
 		{
 			s += std::format(
-				"{:<20}{:<6.2f}{:<6.2f}{:<6.2f}{:<6.2f}\n", label, stat.current, stat.avg(), stat.min, stat.max);
+				"{:<20}{:<7.3f}{:<7.3f}{:<7.3f}{:<7.3f}\n", label, stat.current, stat.avg(), stat.min, stat.max);
 		}
 		timing_text.setString(s);
 	}

--- a/libaudioviz/src/audioviz/fft/FrequencyAnalyzer.cpp
+++ b/libaudioviz/src/audioviz/fft/FrequencyAnalyzer.cpp
@@ -2,7 +2,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
-#include <immintrin.h>
 #include <stdexcept>
 
 namespace audioviz::fft

--- a/libaudioviz/src/audioviz/fft/fftwf_dft_r2c_1d.cpp
+++ b/libaudioviz/src/audioviz/fft/fftwf_dft_r2c_1d.cpp
@@ -7,6 +7,7 @@ namespace audioviz::fft
 void fftwf_dft_r2c_1d::init(const int N)
 {
 	this->N = N;
+	this->outN = N / 2 + 1;
 	in = (float *)fftwf_malloc(sizeof(float) * N);
 	out = (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * output_size());
 	p = fftwf_plan_dft_r2c_1d(N, in, out, FFTW_ESTIMATE);

--- a/tests/spectrum-test.cpp
+++ b/tests/spectrum-test.cpp
@@ -27,16 +27,20 @@ SpectrumTest::SpectrumTest(sf::Vector2u size, const std::string &media_url)
 	ss.set_bar_spacing(5);
 
 	set_audio_frames_needed(fft_size);
-	ss.configure_analyzer(sa);
+	ss.configure_analyzer(sa); // only need to configure once since the spectrum isnt changing size
 
 	set_audio_playback_enabled(true);
+#ifdef __linux__
+	set_timing_text_enabled(true);
+	set_text_font("/usr/share/fonts/TTF/Iosevka-Regular.ttc");
+#endif
 
 	auto &spectrum_layer = add_layer("spectrum");
 	spectrum_layer.add_drawable(&ss);
 	spectrum_layer.set_orig_cb(
 		[&](auto &orig_rt)
 		{
-			sa.analyze(fa, media->audio_buffer().data(), true);
+			perform_fft(fa, sa);
 			ss.update(sa);
 		});
 


### PR DESCRIPTION
Might have fell down the optimization rabbit hole thanks to the `perf` tool. It pointed out some really easy ways to precompute values away from hot code paths. I even tried out explicit AVX instructions but opted not to complicate the codebase like that, and try to hint to the compiler to vectorize code itself. I didn't see a significant speed improvement but I know for a fact this is definitely doing *something*